### PR TITLE
Publish and feature OpenBao etcd encryption post

### DIFF
--- a/src/content/posts/openbao/kubernetes-etcd-encryption-with-openbao-transit.md
+++ b/src/content/posts/openbao/kubernetes-etcd-encryption-with-openbao-transit.md
@@ -1,7 +1,8 @@
 ---
 title: "Kubernetes Etcd Encryption With OpenBao Transit"
 description: "A practical walkthrough of Kubernetes envelope encryption, KMS v2 providers, and a runnable kind lab using OpenBao Transit."
-pubDatetime: 2026-06-07T10:00:00Z
+pubDatetime: 2026-06-07T00:00:00Z
+featured: true
 draft: false
 tags:
   - openbao


### PR DESCRIPTION
## Summary

Publishes the OpenBao/Kubernetes etcd encryption post immediately by moving `pubDatetime` from `2026-06-07T10:00:00Z` to `2026-06-07T00:00:00Z`.

Marks the post as featured so it appears in the homepage featured writing section.

## Validation

- `pnpm run check`
- Verified local preview homepage includes the post under Featured writing
- Verified local preview post route renders at `/posts/openbao/kubernetes-etcd-encryption-with-openbao-transit/`
